### PR TITLE
Change "GPL" to "AGPL" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains an automatically updated dump of Truth Social's source code (reskinned Mastodon). Everything is in the [`source`](/source) folder.
 
-Because Truth Social is reskinned [Mastodon](https://en.wikipedia.org/wiki/Mastodon_(software)), Truth Social is legally required under the GPL to release their source code. They don't make it easy to browse, though. This repository changes that.
+Because Truth Social is reskinned [Mastodon](https://en.wikipedia.org/wiki/Mastodon_(software)), Truth Social is legally required under the AGPL to release their source code. They don't make it easy to browse, though. This repository changes that.
 
 Future improvements:
 


### PR DESCRIPTION
I'm assuming this is just a typo. If Truth Social were just licensed under the GPL, I don't think they would be required to release the source code.